### PR TITLE
Automated Changelog Entry for 0.3.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
 <!-- <START NEW CHANGELOG ENTRY> -->
+
+## 0.3.0
+
+([Full Changelog](https://github.com/jupyterlite/xeus-python-kernel/compare/8166fc63fd8b4f56b39431e810dabbeae842ea83...280c7c60b77d19a161de8256ccda7b77235f5690))
+
+### Merged PRs
+
+- Reduce sdist size [#17](https://github.com/jupyterlite/xeus-python-kernel/pull/17) ([@martinRenou](https://github.com/martinRenou))
+- Update emsdk and empack [#16](https://github.com/jupyterlite/xeus-python-kernel/pull/16) ([@martinRenou](https://github.com/martinRenou))
+- Remove duplication of the labextension [#15](https://github.com/jupyterlite/xeus-python-kernel/pull/15) ([@martinRenou](https://github.com/martinRenou))
+- Rebuild with latest empack [#13](https://github.com/jupyterlite/xeus-python-kernel/pull/13) ([@martinRenou](https://github.com/martinRenou))
+- Add back Changelog [#11](https://github.com/jupyterlite/xeus-python-kernel/pull/11) ([@martinRenou](https://github.com/martinRenou))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/xeus-python-kernel/graphs/contributors?from=2022-05-19&to=2022-05-24&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-python-kernel+involves%3Ajtpio+updated%3A2022-05-19..2022-05-24&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-python-kernel+involves%3AmartinRenou+updated%3A2022-05-19..2022-05-24&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->
 
 ## v0.2.0
@@ -12,7 +31,6 @@
 * Do not use xeus-python's master branch by @martinRenou in https://github.com/jupyterlite/xeus-python-kernel/pull/8
 * Simplify dockerfile by @martinRenou in https://github.com/jupyterlite/xeus-python-kernel/pull/9
 * Xeus python build addon by @martinRenou in https://github.com/jupyterlite/xeus-python-kernel/pull/10
-
 
 **Full Changelog**: https://github.com/jupyterlite/xeus-python-kernel/compare/0.1.0...0.2.0
 


### PR DESCRIPTION
Automated Changelog Entry for 0.3.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/xeus-python-kernel  |
| Branch  | main  |
| Version Spec | 0.3.0 |
| Since | 8166fc63fd8b4f56b39431e810dabbeae842ea83 |