### PR TITLE
Add xeus-python services

### DIFF
--- a/jupyterlite_xeus_python/env_build_addon.py
+++ b/jupyterlite_xeus_python/env_build_addon.py
@@ -17,6 +17,8 @@ from jupyterlite.addons.federated_extensions import FederatedExtensionAddon
 
 PYTHON_VERSION = "3.10"
 
+SERVICE = "xeus_python_service.js"
+
 CHANNELS = [
     "https://repo.mamba.pm/emscripten-forge",
     "https://repo.mamba.pm/conda-forge"
@@ -89,9 +91,14 @@ class XeusPythonEnv(FederatedExtensionAddon):
 
     def pre_build(self, manager):
         """yield a doit task to create the emscripten-32 env and grab anything we need from it"""
+        yield dict(
+            name="setup-service-worker",
+            actions=[(self.copy_one, [Path(__file__).parent / SERVICE, Path(self.manager.output_dir) / SERVICE])],
+        )
+
         # Bail early if there is nothing to do
         if not self.packages:
-            return []
+            return
 
         # Create emscripten env with the given packages
         self.create_env()

--- a/jupyterlite_xeus_python/xeus_python_service.js
+++ b/jupyterlite_xeus_python/xeus_python_service.js
@@ -1,0 +1,24 @@
+self.addEventListener("install", (event) => {
+    console.log('install xeus-python service');
+    event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', (event) => {
+    console.log('activate xeus-python service');
+    event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', (event) => {
+    var url = new URL(event.request.url);
+    if (url.pathname === '/SLEEP') {
+        console.log('SLEEP', event);
+
+        // wait ?t=X seconds, then return a 304:
+        event.respondWith(new Promise(resolve => {
+            var t = Number.parseFloat(new URLSearchParams(url.search).get('t')) * 1000.;
+            var response = new Response(null, { status: 304 });
+
+            setTimeout(resolve, t, response);
+        }));
+    }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,20 @@ const server_kernel: JupyterLiteServerPlugin<void> = {
         });
       }
     });
+
+    navigator.serviceWorker.register('/xeus_python_service.js').then(
+      registration => {
+        // Registration was successful
+        console.log(
+          'ServiceWorker registration successful with scope: ',
+          registration.scope
+        );
+      },
+      err => {
+        // registration failed :(
+        console.log('ServiceWorker registration failed: ', err);
+      }
+    );
   }
 };
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -11,6 +11,19 @@ const ctx: Worker = self as any;
 let raw_xkernel: any;
 let raw_xserver: any;
 
+function sleep(seconds: number) {
+  const xhr = new XMLHttpRequest();
+  xhr.open('GET', `/SLEEP?t=${seconds}`, false);
+  try{
+    xhr.send();
+  } catch(e) {
+    console.error(e);
+  }
+}
+
+// sleep(2);
+// sleep(3);
+
 async function waitRunDependency() {
   const promise = new Promise((r: any) => {
     globalThis.Module.monitorRunDependencies = (n: number) => {


### PR DESCRIPTION
Adding a service worker globally usable by all xeus-python kernels for sleeping.

Ideas for xeus-python services usage:
- make the `requests` Python package work with this?
- make the `input` blocking?
- make the `with open('file.txt')` work with this by requesting to the browser local storage?

This should probably be upstreamed to jupyterlite so that it's usable by all kernels