### PR TITLE
Fix hanging jupyterlite build via jupyterlite-sphinx

### DIFF
--- a/jupyterlite_xeus_python/env_build_addon.py
+++ b/jupyterlite_xeus_python/env_build_addon.py
@@ -194,6 +194,7 @@ class XeusPythonEnv(FederatedExtensionAddon):
             [
                 conda,
                 "create",
+                "--yes",
                 "--prefix",
                 self.prefix_path,
                 *channels
@@ -205,6 +206,7 @@ class XeusPythonEnv(FederatedExtensionAddon):
             [
                 conda,
                 "install",
+                "--yes",
                 "--prefix",
                 self.prefix_path,
                 *channels,


### PR DESCRIPTION
This should fix the `jupyter lite build` command that is waiting infinitely when run via sphinx-build.