### PR TITLE
Fix plugin id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import logo32 from '../style/logos/python-logo-32x32.png';
 import logo64 from '../style/logos/python-logo-64x64.png';
 
 const server_kernel: JupyterLiteServerPlugin<void> = {
-  id: '@jupyterlite/xeus-kernel-extension:kernel',
+  id: '@jupyterlite/xeus-python-kernel-extension:kernel',
   autoStart: true,
   requires: [IKernelSpecs, IServiceWorkerRegistrationWrapper],
   activate: (


### PR DESCRIPTION
Set the plugin id to `@jupyterlite/xeus-python-kernel-extension:kernel` to avoid collisions with other xeus based kernels, which would otherwise result in plugin activation errors:

![image](https://user-images.githubusercontent.com/591645/176004470-0106c0eb-f3c1-4474-b4c0-b2b391765afa.png)
