### PR TITLE
Remove leading space in the replite default example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ How does it compare with JupyterLite's ``Pyolite``?
    :kernel: xeus-python
    :height: 600px
 
-    print("Hello from xeus-python!")
+   print("Hello from xeus-python!")
 
 .. toctree::
     :caption: Installation


### PR DESCRIPTION
A small thing but there seems to be an extra leading space with the default example in the documentation: https://xeus-python-kernel.readthedocs.io/en/latest/

![image](https://user-images.githubusercontent.com/591645/176210525-74c64c6c-8d13-47d0-9f55-71a8878899c0.png)
