### PR TITLE
Automated Changelog Entry for 0.5.6 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ([Full Changelog](https://github.com/jupyterlite/xeus-python-kernel/compare/v0.5.5...fd6ab092a2820d3bd619792623d22599263ca580))
 
-### Merged PRs
+### Bug fix
 
 - Fix caching issue [#73](https://github.com/jupyterlite/xeus-python-kernel/pull/73) ([@martinRenou](https://github.com/martinRenou))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.5.6
+
+([Full Changelog](https://github.com/jupyterlite/xeus-python-kernel/compare/v0.5.5...fd6ab092a2820d3bd619792623d22599263ca580))
+
+### Merged PRs
+
+- Fix caching issue [#73](https://github.com/jupyterlite/xeus-python-kernel/pull/73) ([@martinRenou](https://github.com/martinRenou))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/xeus-python-kernel/graphs/contributors?from=2022-08-17&to=2022-08-30&type=c))
+
+[@martinRenou](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-python-kernel+involves%3AmartinRenou+updated%3A2022-08-17..2022-08-30&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.5.5
 
 ([Full Changelog](https://github.com/jupyterlite/xeus-python-kernel/compare/v0.5.4...2e2458ec83390d03616c4a7bc2d96950cb6510fe))
@@ -15,8 +31,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/xeus-python-kernel/graphs/contributors?from=2022-08-16&to=2022-08-17&type=c))
 
 [@martinRenou](https://github.com/search?q=repo%3Ajupyterlite%2Fxeus-python-kernel+involves%3AmartinRenou+updated%3A2022-08-16..2022-08-17&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.5.4
 


### PR DESCRIPTION
Automated Changelog Entry for 0.5.6 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/xeus-python-kernel  |
| Branch  | main  |
| Version Spec | 0.5.6 |
| Since | v0.5.5 |