### PR TITLE
Specify linux/amd64 for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:0.23.1
+FROM --platform=linux/amd64 mambaorg/micromamba:0.23.1 as build
 
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 ARG PYTHON_VERSION=3.10


### PR DESCRIPTION
I was trying to build the docker image on a Mac but kept getting libmamba "cannot find requested empack" errors. Turns out it was because docker was defaulting to using a linux aarch64 image which doesn't have packages available on the mamba channels. Solved it by specifying the linux/amd64 platform such that docker should use that image and its corresponding packages. Maybe other platforms are supported? Any ideas to not force emulating linux/amd64 are welcome. Nevertheless seems like a good default just in case.