### PR TITLE
Add support for pip dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,6 @@ You can also pick another name for that environment file (*e.g.* `custom.yml`), 
 jupyter lite build --XeusPythonEnv.environment_file=custom.yml
 ```
 
-#### About pip dependencies
-
-It is common to provide `pip` dependencies in a conda environment file, this is currently **not supported** by xeus-python.
-
 ## Contributing
 
 ### Development install

--- a/docs/build-environment.yml
+++ b/docs/build-environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - yarn
   - jupyterlab >=3.5.3,<3.6
   - jupyterlite-core >=0.1.0,<0.2.0
+  - jupyterlite-sphinx
+  - empack >=3.1.0
   - pip:
-    - jupyterlite-sphinx
-    - git+https://github.com/martinRenou/empack.git@pip
     - ..

--- a/docs/build-environment.yml
+++ b/docs/build-environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - yarn
   - jupyterlab >=3.5.3,<3.6
   - jupyterlite-core >=0.1.0,<0.2.0
-  - empack >=3,<4
   - pip:
     - jupyterlite-sphinx
+    - git+https://github.com/martinRenou/empack.git@pip
     - ..

--- a/docs/build-environment.yml
+++ b/docs/build-environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - yarn
   - jupyterlab >=3.5.3,<3.6
   - jupyterlite-core >=0.1.0,<0.2.0
-  - jupyterlite-sphinx
   - empack >=3.1.0
   - pip:
+    - jupyterlite-sphinx >=0.9.1
     - ..

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 
 extensions = [
-    'jupyterlite_sphinx',
-    'myst_parser',
+    "jupyterlite_sphinx",
+    "myst_parser",
 ]
 
 myst_enable_extensions = [
     "linkify",
 ]
 
-master_doc = 'index'
-source_suffix = '.rst'
+master_doc = "index"
+source_suffix = ".rst"
 
-project = 'jupyterlite-xeus-python'
-copyright = 'JupyterLite Team'
-author = 'JupyterLite Team'
+project = "jupyterlite-xeus-python"
+copyright = "JupyterLite Team"
+author = "JupyterLite Team"
 
 exclude_patterns = []
 
@@ -23,8 +23,8 @@ html_theme = "pydata_sphinx_theme"
 jupyterlite_dir = "."
 
 html_theme_options = {
-   "logo": {
-      "image_light": "xeus-python.svg",
-      "image_dark": "xeus-python.svg",
-   }
+    "logo": {
+        "image_light": "xeus-python.svg",
+        "image_dark": "xeus-python.svg",
+    }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,12 +13,12 @@ Say you want to install `NumPy`, `Matplotlib` and `ipycanvas`, it can be done by
 ```
 name: xeus-python-kernel
 channels:
-- https://repo.mamba.pm/emscripten-forge
-- https://repo.mamba.pm/conda-forge
+  - https://repo.mamba.pm/emscripten-forge
+  - https://repo.mamba.pm/conda-forge
 dependencies:
-- numpy
-- matplotlib
-- ipycanvas
+  - numpy
+  - matplotlib
+  - ipycanvas
 ```
 
 Then you only need to build JupyterLite:
@@ -33,8 +33,8 @@ You can also pick another name for that environment file (*e.g.* `custom.yml`), 
 jupyter lite build --XeusPythonEnv.environment_file=custom.yml
 ```
 
-```{note}
-It is common to provide `pip` dependencies in a conda environment file. This is currently **not supported** by xeus-python, but there is a [work-in-progress](https://github.com/jupyterlite/xeus-python-kernel/pull/102) to support it.
+```{warning}
+It is common to provide `pip` dependencies in a conda environment file. This is currently **partially supported** by xeus-python. See "pip packages" section.
 ```
 
 Then those packages are usable directly:
@@ -53,6 +53,31 @@ Then those packages are usable directly:
    fig = plt.figure()
    plt.plot(np.sin(np.linspace(0, 20, 100)))
    plt.show();
+```
+
+### pip packages
+
+⚠ This feature is experimental. You won't have the same user-experience as when using conda/mamba in a "normal" setup ⚠
+
+`xeus-python` provides a way to install packages with pip.
+
+There are a couple of limitations that you should be aware of:
+- it can only install pure Python packages (Python code + data files)
+- it does not install the package dependencies, you should make sure to install them yourself using conda-forge/emscripten-forge.
+
+For example, if you were to install `ipycanvas` from PyPI, you would need to install the ipycanvas dependencies for it to work (`pillow`, `numpy` and `ipywidgets`):
+
+```
+name: xeus-python-kernel
+channels:
+  - https://repo.mamba.pm/emscripten-forge
+  - https://repo.mamba.pm/conda-forge
+dependencies:
+  - numpy
+  - pillow
+  - ipywidgets
+  - pip:
+    - ipycanvas
 ```
 
 ## Advanced Configuration

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,4 +5,6 @@ channels:
 dependencies:
   - numpy
   - matplotlib
-  - ipycanvas
+  - mpmath
+  - pip:
+    - ipycanvas

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - numpy
   - matplotlib
-  - mpmath
+  - pillow
+  - ipywidgets
   - pip:
     - ipycanvas

--- a/jupyterlite_xeus_python/build.py
+++ b/jupyterlite_xeus_python/build.py
@@ -226,9 +226,7 @@ def build_and_pack_emscripten_env(
                     yaml.safe_load(empack_config_content)
                 )
             else:
-                pack_kwargs["file_filters"] = pkg_file_filter_from_yaml(
-                    empack_config
-                )
+                pack_kwargs["file_filters"] = pkg_file_filter_from_yaml(empack_config)
         else:
             pack_kwargs["file_filters"] = pkg_file_filter_from_yaml(DEFAULT_CONFIG_PATH)
 
@@ -258,13 +256,16 @@ def build_and_pack_emscripten_env(
 
             worker = worker.replace("XEUS_KERNEL_FILE", "'xpython_wasm.js'")
             worker = worker.replace("LANGUAGE_DATA_FILE", "'python_data.js'")
-            worker = worker.replace("importScripts(DATA_FILE);", """
+            worker = worker.replace(
+                "importScripts(DATA_FILE);",
+                """
                 await globalThis.Module.bootstrap_from_empack_packed_environment(
                 `./empack_env_meta.json`, /* packages_json_url */
                 ".",               /* package_tarballs_root_url */
                 false              /* verbose */
             );
-            """)
+            """,
+            )
             with open(Path(output_path) / "worker.ts", "w") as fobj:
                 fobj.write(worker)
 

--- a/jupyterlite_xeus_python/build.py
+++ b/jupyterlite_xeus_python/build.py
@@ -167,7 +167,8 @@ def _install_pip_dependencies(prefix_path, dependencies, log=None):
 
     for package_dist_info in packages_dist_info:
         with open(package_dist_info / "RECORD", "r") as record:
-            record_csv = csv.reader(record)
+            record_content = record.read()
+            record_csv = csv.reader(record_content.splitlines())
             all_files = [_file[0] for _file in record_csv]
 
             non_supported_files = [".so", ".a", ".dylib", ".lib", ".exe" ".dll"]
@@ -178,11 +179,11 @@ def _install_pip_dependencies(prefix_path, dependencies, log=None):
             ]
 
             # Why?
-            record_data = record.read().replace("../../", "../../../")
+            fixed_record_data = record_content.replace("../../", "../../../")
 
         # OVERWRITE RECORD file
         with open(package_dist_info / "RECORD", "w") as record:
-            record.write(record_data)
+            record.write(fixed_record_data)
 
         # COPY files under `prefix_path`
         for (_file, inside_site_packages) in files:

--- a/jupyterlite_xeus_python/build.py
+++ b/jupyterlite_xeus_python/build.py
@@ -190,7 +190,7 @@ def _install_pip_dependencies(prefix_path, dependencies, log=None):
             # FAIL if .so / .a / .dylib / .lib / .exe / .dll
             if path.suffix in non_supported_files:
                 raise RuntimeError(
-                    "Cannot install binary PyPi package, only pure Python packages are supported"
+                    "Cannot install binary PyPI package, only pure Python packages are supported"
                 )
 
             file_path = _file[6:] if not inside_site_packages else _file

--- a/jupyterlite_xeus_python/build.py
+++ b/jupyterlite_xeus_python/build.py
@@ -174,9 +174,7 @@ def _install_pip_dependencies(prefix_path, dependencies, log=None):
             non_supported_files = [".so", ".a", ".dylib", ".lib", ".exe" ".dll"]
 
             # List of tuples: (path: str, inside_site_packages: bool)
-            files = [
-                (_file, not _file.startswith("../../")) for _file in all_files
-            ]
+            files = [(_file, not _file.startswith("../../")) for _file in all_files]
 
             # Why?
             fixed_record_data = record_content.replace("../../", "../../../")
@@ -186,15 +184,21 @@ def _install_pip_dependencies(prefix_path, dependencies, log=None):
             record.write(fixed_record_data)
 
         # COPY files under `prefix_path`
-        for (_file, inside_site_packages) in files:
+        for _file, inside_site_packages in files:
             path = Path(_file)
 
             # FAIL if .so / .a / .dylib / .lib / .exe / .dll
             if path.suffix in non_supported_files:
-                raise RuntimeError("Cannot install binary PyPi package, only pure Python packages are supported")
+                raise RuntimeError(
+                    "Cannot install binary PyPi package, only pure Python packages are supported"
+                )
 
             file_path = _file[6:] if not inside_site_packages else _file
-            install_path = prefix_path if not inside_site_packages else prefix_path / "lib" / f"python{PYTHON_VERSION}" / "site-packages"
+            install_path = (
+                prefix_path
+                if not inside_site_packages
+                else prefix_path / "lib" / f"python{PYTHON_VERSION}" / "site-packages"
+            )
 
             src_path = Path(pkg_dir.name) / file_path
             dest_path = install_path / file_path

--- a/jupyterlite_xeus_python/env_build_addon.py
+++ b/jupyterlite_xeus_python/env_build_addon.py
@@ -38,7 +38,6 @@ class PackagesList(List):
 
 
 class XeusPythonEnv(FederatedExtensionAddon):
-
     __all__ = ["post_build"]
 
     xeus_python_version = Unicode(XEUS_PYTHON_VERSION).tag(
@@ -99,16 +98,13 @@ class XeusPythonEnv(FederatedExtensionAddon):
         dest = self.output_extensions / "@jupyterlite" / "xeus-python-kernel" / "static"
 
         # copy *.tar.gz for all side packages
-        for item in Path(self.cwd.name) .iterdir():
+        for item in Path(self.cwd.name).iterdir():
             if item.suffix == ".gz":
-
                 file = item.name
                 yield dict(
                     name=f"xeus:copy:{file}",
                     actions=[(self.copy_one, [item, dest / file])],
                 )
-
-
 
         for file in [
             "empack_env_meta.json",

--- a/jupyterlite_xeus_python/env_build_addon.py
+++ b/jupyterlite_xeus_python/env_build_addon.py
@@ -85,6 +85,7 @@ class XeusPythonEnv(FederatedExtensionAddon):
             environment_file=Path(self.manager.lite_dir) / self.environment_file,
             empack_config=self.empack_config,
             output_path=self.cwd.name,
+            log=self.log,
         )
 
         # Find the federated extensions in the emscripten-env and install them

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup_args = dict(
         "traitlets",
         "jupyterlite-core>=0.1.0",
         "requests",
-        "empack>=3,<4",
+        "empack>=3.1,<4",
         "typer",
     ],
     zip_safe=False,

--- a/tests/test_xeus_python_env.py
+++ b/tests/test_xeus_python_env.py
@@ -23,8 +23,12 @@ def test_python_env():
     # Check env
     assert os.path.isdir("/tmp/xeus-python-kernel/envs/xeus-python-kernel")
 
-    assert os.path.isfile("/tmp/xeus-python-kernel/envs/xeus-python-kernel/bin/xpython_wasm.js")
-    assert os.path.isfile("/tmp/xeus-python-kernel/envs/xeus-python-kernel/bin/xpython_wasm.wasm")
+    assert os.path.isfile(
+        "/tmp/xeus-python-kernel/envs/xeus-python-kernel/bin/xpython_wasm.js"
+    )
+    assert os.path.isfile(
+        "/tmp/xeus-python-kernel/envs/xeus-python-kernel/bin/xpython_wasm.wasm"
+    )
 
     # Check empack output
     assert os.path.isfile(Path(addon.cwd.name) / "empack_env_meta.json")
@@ -46,8 +50,12 @@ def test_python_env_from_file_1():
     # Check env
     assert os.path.isdir("/tmp/xeus-python-kernel/envs/xeus-python-kernel-1")
 
-    assert os.path.isfile("/tmp/xeus-python-kernel/envs/xeus-python-kernel-1/bin/xpython_wasm.js")
-    assert os.path.isfile("/tmp/xeus-python-kernel/envs/xeus-python-kernel-1/bin/xpython_wasm.wasm")
+    assert os.path.isfile(
+        "/tmp/xeus-python-kernel/envs/xeus-python-kernel-1/bin/xpython_wasm.js"
+    )
+    assert os.path.isfile(
+        "/tmp/xeus-python-kernel/envs/xeus-python-kernel-1/bin/xpython_wasm.wasm"
+    )
 
     # Check empack output
     assert os.path.isfile(Path(addon.cwd.name) / "empack_env_meta.json")


### PR DESCRIPTION
Would fix #100 and probably fix https://github.com/jupyterlite/xeus-python-kernel/issues/48

This is very much experimental for now.

Pip is running with the `--no-deps` option, meaning that the user would need to install the package dependencies from conda-forge/emscripten-forge/PyPI themselves.

Pip is not made for installing packages in another environment (it is supposed to install packages for the Python version it uses, nothing else), so we have to workaround this by doing some shenanigans to make it work. The `--no-deps` option is one of those workarounds.

I don't think we should support reading some `requirements.txt` file for now, at least not before pip packages are more correctly supported, if they ever are.