### PR TITLE
Use shutil.which() in subprocess.check_call() when executing mamba/micromamba/conda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ src/web_worker_kernel.ts
 
 # Labextension
 share
+
+# venv
+.venv

--- a/jupyterlite_xeus_python/env_build_addon.py
+++ b/jupyterlite_xeus_python/env_build_addon.py
@@ -48,20 +48,32 @@ except ImportError:
     MAMBA_PYTHON_AVAILABLE = False
 
 try:
-    check_call(["mamba", "--version"], **SILENT)
-    MAMBA_AVAILABLE = True
+    MAMBA_COMMAND = shutil.which("mamba")
+    if MAMBA_COMMAND:
+        check_call([MAMBA_COMMAND, "--version"], **SILENT)
+        MAMBA_AVAILABLE = True
+    else:
+        MAMBA_AVAILABLE = False
 except FileNotFoundError:
     MAMBA_AVAILABLE = False
 
 try:
-    check_call(["micromamba", "--version"], **SILENT)
-    MICROMAMBA_AVAILABLE = True
+    MICROMAMBA_COMMAND = shutil.which("micromamba")
+    if MICROMAMBA_COMMAND:
+        check_call([MICROMAMBA_COMMAND, "--version"], **SILENT)
+        MICROMAMBA_AVAILABLE = True
+    else:
+        MICROMAMBA_AVAILABLE = False
 except FileNotFoundError:
     MICROMAMBA_AVAILABLE = False
 
 try:
-    check_call(["conda", "--version"], **SILENT)
-    CONDA_AVAILABLE = True
+    CONDA_COMMAND = shutil.which("conda")
+    if CONDA_COMMAND:
+        check_call([CONDA_COMMAND, "--version"], **SILENT)
+        CONDA_AVAILABLE = True
+    else:
+        CONDA_AVAILABLE = False
 except FileNotFoundError:
     CONDA_AVAILABLE = False
 
@@ -255,12 +267,12 @@ class XeusPythonEnv(FederatedExtensionAddon):
         if MAMBA_AVAILABLE:
             # Mamba needs the directory to exist already
             self.prefix_path.mkdir(parents=True, exist_ok=True)
-            return self._create_env_with_config("mamba", channels)
+            return self._create_env_with_config(MAMBA_COMMAND, channels)
 
         if MICROMAMBA_AVAILABLE:
             run(
                 [
-                    "micromamba",
+                    MICROMAMBA_COMMAND,
                     "create",
                     "--yes",
                     "--root-prefix",
@@ -277,7 +289,7 @@ class XeusPythonEnv(FederatedExtensionAddon):
             return
 
         if CONDA_AVAILABLE:
-            return self._create_env_with_config("conda", channels)
+            return self._create_env_with_config(CONDA_COMMAND, channels)
 
         raise RuntimeError(
             """Failed to create the virtual environment for xeus-python,


### PR DESCRIPTION
This PR implement a [recommendation](https://docs.python.org/3/library/subprocess.html#:~:text=For%20maximum%20reliability%2C%20use%20a%20fully%20qualified%20path%20for%20the%20executable.%20To%20search%20for%20an%20unqualified%20name%20on%20PATH%2C%20use%20shutil.which()) from the Python documentation for the Popen constructor: "For maximum reliability, use a fully qualified path for the executable. To search for an unqualified name on PATH, use shutil.which()".

Practically, this PR fixes conda/mamba execution on Windows as we can see from the following examples.

Linux:
```
username:~$ conda --version
conda 22.11.1
username:~$ python -c "import subprocess; subprocess.check_call(['conda','--version'])"
conda 22.11.1
username:~$ python -c "import subprocess; import shutil; subprocess.check_call([shutil.which('conda'),'--version'])"
conda 22.11.1
```

Windows:
```
C:\Users\un>conda --version
conda 22.9.0

C:\Users\un>python -c "import subprocess; subprocess.check_call(['conda','--version'])"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\neboj\anaconda3\envs\build-env\Lib\subprocess.py", line 408, in check_call
    retcode = call(*popenargs, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\neboj\anaconda3\envs\build-env\Lib\subprocess.py", line 389, in call
    with Popen(*popenargs, **kwargs) as p:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\neboj\anaconda3\envs\build-env\Lib\subprocess.py", line 1022, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "C:\Users\neboj\anaconda3\envs\build-env\Lib\subprocess.py", line 1491, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [WinError 2] The system cannot find the file specified

C:\Users\un>python -c "import subprocess; import shutil; subprocess.check_call([shutil.which('conda'),'--version'])"
conda 22.9.0
```