### PR TITLE
Depend on `jupyterlite-core`

### DIFF
--- a/docs/build-environment.yml
+++ b/docs/build-environment.yml
@@ -13,6 +13,6 @@ dependencies:
   - jupyterlab
   - empack >=2.0.9,<3
   - pip:
-    - jupyterlite-core @ https://jupyterlite--994.org.readthedocs.build/en/994/_static/jupyterlite_core-0.1.0b18-py3-none-any.whl
+    - jupyterlite-core==0.1.0b19
     - jupyterlite-sphinx
     - ..

--- a/docs/build-environment.yml
+++ b/docs/build-environment.yml
@@ -13,6 +13,6 @@ dependencies:
   - jupyterlab
   - empack >=2.0.9,<3
   - pip:
-    - jupyterlite==0.1.0b18
+    - jupyterlite-core @ https://jupyterlite--994.org.readthedocs.build/en/994/_static/jupyterlite_core-0.1.0b18-py3-none-any.whl
     - jupyterlite-sphinx
     - ..

--- a/docs/jupyter-lite.json
+++ b/docs/jupyter-lite.json
@@ -2,8 +2,7 @@
   "jupyter-lite-schema-version": 0,
   "jupyter-config-data": {
     "disabledExtensions": [
-      "@jupyterlite/javascript-kernel-extension",
-      "@jupyterlite/pyolite-kernel-extension"
+      "@jupyterlite/javascript-kernel-extension"
     ]
   }
 }

--- a/jupyterlite_xeus_python/env_build_addon.py
+++ b/jupyterlite_xeus_python/env_build_addon.py
@@ -15,14 +15,14 @@ from traitlets import List, Unicode
 from empack.file_packager import pack_environment
 from empack.file_patterns import PkgFileFilter, pkg_file_filter_from_yaml
 
-from jupyterlite.constants import (
+from jupyterlite_core.constants import (
     SHARE_LABEXTENSIONS,
     LAB_EXTENSIONS,
     JUPYTERLITE_JSON,
     UTF8,
     FEDERATED_EXTENSIONS,
 )
-from jupyterlite.addons.federated_extensions import (
+from jupyterlite_core.addons.federated_extensions import (
     FederatedExtensionAddon,
     ENV_EXTENSIONS,
 )

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup_args = dict(
     packages=setuptools.find_packages(exclude=["tests"]),
     install_requires=[
         "traitlets",
-        "jupyterlite-core @ https://jupyterlite--994.org.readthedocs.build/en/994/_static/jupyterlite_core-0.1.0b18-py3-none-any.whl",
+        "jupyterlite-core>=0.1.0b19",
         "requests",
         "empack>=2.0.9,<3",
         "typer",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup_args = dict(
     packages=setuptools.find_packages(exclude=["tests"]),
     install_requires=[
         "traitlets",
-        "jupyterlite",
+        "jupyterlite-core @ https://jupyterlite--994.org.readthedocs.build/en/994/_static/jupyterlite_core-0.1.0b18-py3-none-any.whl",
         "requests",
         "empack>=2.0.9,<3",
         "typer",

--- a/tests/test_xeus_python_env.py
+++ b/tests/test_xeus_python_env.py
@@ -4,7 +4,7 @@ import os
 from tempfile import TemporaryDirectory
 from pathlib import Path
 
-from jupyterlite.app import LiteStatusApp
+from jupyterlite_core.app import LiteStatusApp
 
 from jupyterlite_xeus_python.env_build_addon import XeusPythonEnv
 


### PR DESCRIPTION
The core functionality of the `jupyterlite` package is being extracted to a new `jupyterlite-core` package in https://github.com/jupyterlite/jupyterlite/pull/994.

This will allow site deployers to make slimmer deployments without having to bring the Pyodide kernel as well.

And let them use alternative kernels like Xeus Python only if they want to.

### TODO

- [x] Try depending on `jupyterlite-core` built from https://github.com/jupyterlite/jupyterlite/pull/994
- [x] Update to the real `jupyterlite-core` dependency when a release is available (likely after https://github.com/jupyterlite/jupyterlite/pull/994 is merged)
- [x] Update the docs environment