### PR TITLE
Update to `jupyterlite-core==0.1.0b20`

### DIFF
--- a/docs/build-environment.yml
+++ b/docs/build-environment.yml
@@ -13,6 +13,6 @@ dependencies:
   - jupyterlab
   - empack >=2.0.9,<3
   - pip:
-    - jupyterlite-core==0.1.0b19
+    - jupyterlite-core==0.1.0b20
     - jupyterlite-sphinx
     - ..

--- a/docs/jupyter-lite.json
+++ b/docs/jupyter-lite.json
@@ -1,8 +1,0 @@
-{
-  "jupyter-lite-schema-version": 0,
-  "jupyter-config-data": {
-    "disabledExtensions": [
-      "@jupyterlite/javascript-kernel-extension"
-    ]
-  }
-}

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup_args = dict(
     packages=setuptools.find_packages(exclude=["tests"]),
     install_requires=[
         "traitlets",
-        "jupyterlite-core>=0.1.0b19",
+        "jupyterlite-core>=0.1.0b20",
         "requests",
         "empack>=2.0.9,<3",
         "typer",

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup_args = dict(
     ],
     zip_safe=False,
     include_package_data=True,
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     platforms="Linux, Mac OS X, Windows",
     keywords=["Jupyter", "JupyterLab", "JupyterLab3"],
     classifiers=[


### PR DESCRIPTION
## References

Update to the latest `jupyterlite-core`: https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0b20

Which does not include the JavaScript kernel by default anymore: https://github.com/jupyterlite/jupyterlite/pull/1013

## Code changes

- [x] Update to `jupyterlite-core==0.1.0b20`
- [x] Require Python 3.8

## User-facing changes

The JavaScript kernel should not be available by default on the demo site in the docs.

## Backwards-incompatible changes

None
