### PR TITLE
Update default Python to 3.11

### DIFF
--- a/jupyterlite_xeus_python/build.py
+++ b/jupyterlite_xeus_python/build.py
@@ -25,7 +25,7 @@ MAMBA_COMMAND = shutil.which("mamba")
 MICROMAMBA_COMMAND = shutil.which("micromamba")
 CONDA_COMMAND = shutil.which("conda")
 
-PYTHON_VERSION = "3.10"
+PYTHON_VERSION = "3.11"
 
 CHANNELS = [
     "https://repo.mamba.pm/emscripten-forge",


### PR DESCRIPTION
Update the default Python to version `3.11`.

Would need https://github.com/emscripten-forge/recipes/pull/303 first.