### PR TITLE
Compute local package dir when pip install

### DIFF
--- a/tests/test_package/environment-3.yml
+++ b/tests/test_package/environment-3.yml
@@ -1,0 +1,7 @@
+name: xeus-python-kernel-3
+channels:
+  - https://repo.mamba.pm/emscripten-forge
+  - https://repo.mamba.pm/conda-forge
+dependencies:
+  - pip:
+    - .

--- a/tests/test_package/environment-3.yml
+++ b/tests/test_package/environment-3.yml
@@ -3,5 +3,6 @@ channels:
   - https://repo.mamba.pm/emscripten-forge
   - https://repo.mamba.pm/conda-forge
 dependencies:
+  - numpy
   - pip:
     - .

--- a/tests/test_package/pyproject.toml
+++ b/tests/test_package/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "test-package"
+version = "0.1.0"

--- a/tests/test_package/test_package/hey.py
+++ b/tests/test_package/test_package/hey.py
@@ -1,0 +1,1 @@
+print('Hey')

--- a/tests/test_xeus_python_env.py
+++ b/tests/test_xeus_python_env.py
@@ -121,3 +121,5 @@ def test_python_env_from_file_3():
     assert os.path.isfile(
         "/tmp/xeus-python-kernel/envs/xeus-python-kernel-3/lib/python3.10/site-packages/test_package/hey.py"
     )
+
+    os.remove(Path(addon.cwd.name) / "empack_env_meta.json")

--- a/tests/test_xeus_python_env.py
+++ b/tests/test_xeus_python_env.py
@@ -116,8 +116,8 @@ def test_python_env_from_file_3():
 
     # Test
     assert os.path.isdir(
-        "/tmp/xeus-python-kernel/envs/xeus-python-kernel-1/lib/python3.10/site-packages/test_package"
+        "/tmp/xeus-python-kernel/envs/xeus-python-kernel-3/lib/python3.10/site-packages/test_package"
     )
     assert os.path.isfile(
-        "/tmp/xeus-python-kernel/envs/xeus-python-kernel-1/lib/python3.10/site-packages/test_package/hey.py"
+        "/tmp/xeus-python-kernel/envs/xeus-python-kernel-3/lib/python3.10/site-packages/test_package/hey.py"
     )

--- a/tests/test_xeus_python_env.py
+++ b/tests/test_xeus_python_env.py
@@ -90,19 +90,6 @@ def test_python_env_from_file_1():
     os.remove(Path(addon.cwd.name) / "empack_env_meta.json")
 
 
-def test_python_env_from_file_2():
-    app = LiteStatusApp(log_level="DEBUG")
-    app.initialize()
-    manager = app.lite_manager
-
-    addon = XeusPythonEnv(manager)
-    addon.environment_file = "environment-2.yml"
-
-    with pytest.raises(RuntimeError, match="Cannot install binary PyPI package"):
-        for step in addon.post_build(manager):
-            pass
-
-
 def test_python_env_from_file_3():
     app = LiteStatusApp(log_level="DEBUG")
     app.initialize()
@@ -123,3 +110,16 @@ def test_python_env_from_file_3():
     )
 
     os.remove(Path(addon.cwd.name) / "empack_env_meta.json")
+
+
+def test_python_env_from_file_2():
+    app = LiteStatusApp(log_level="DEBUG")
+    app.initialize()
+    manager = app.lite_manager
+
+    addon = XeusPythonEnv(manager)
+    addon.environment_file = "environment-2.yml"
+
+    with pytest.raises(RuntimeError, match="Cannot install binary PyPI package"):
+        for step in addon.post_build(manager):
+            pass

--- a/tests/test_xeus_python_env.py
+++ b/tests/test_xeus_python_env.py
@@ -101,3 +101,23 @@ def test_python_env_from_file_2():
     with pytest.raises(RuntimeError, match="Cannot install binary PyPI package"):
         for step in addon.post_build(manager):
             pass
+
+
+def test_python_env_from_file_3():
+    app = LiteStatusApp(log_level="DEBUG")
+    app.initialize()
+    manager = app.lite_manager
+
+    addon = XeusPythonEnv(manager)
+    addon.environment_file = "test_package/environment-3.yml"
+
+    for step in addon.post_build(manager):
+        pass
+
+    # Test
+    assert os.path.isdir(
+        "/tmp/xeus-python-kernel/envs/xeus-python-kernel-1/lib/python3.10/site-packages/test_package"
+    )
+    assert os.path.isfile(
+        "/tmp/xeus-python-kernel/envs/xeus-python-kernel-1/lib/python3.10/site-packages/test_package/hey.py"
+    )


### PR DESCRIPTION
This would fix issues for when the environment file is not at the same location as where we are running jupyterlite 