### PR TITLE
Make sure to share all packages coming from jupyterlite

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,10 @@
         "bundled": false,
         "singleton": true
       },
+      "@jupyterlite/server": {
+        "bundled": false,
+        "singleton": true
+      },
       "@jupyterlite/contents": {
         "bundled": false,
         "singleton": true


### PR DESCRIPTION
I was hoping to fix the errors that happen whenever jupyterlite gets released and then we have packages out of sync (like in https://github.com/jupyterlite/pyodide-kernel/pull/55)

But I see that the pyodide kernel is also sharing those dependencies properly.

So I don't know if this patch will make things better in the future, at least it won't be harmful.