### PR TITLE
Add `enforce-label` workflow

### DIFF
--- a/.github/workflows/enforce-label.yml
+++ b/.github/workflows/enforce-label.yml
@@ -1,0 +1,16 @@
+name: Enforce PR label
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: enforce-triage-label
+        uses: jupyterlab/maintainer-tools/.github/actions/enforce-label@v1


### PR DESCRIPTION
To be sure to not miss adding the GitHub label, so the generated changelog is nicely formatted.